### PR TITLE
Foundation changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,12 +6,14 @@ import PackageDescription
 extension String {
     static let htmlTypes: Self = "HTMLTypes"
     static let htmlAttributes: Self = "HTMLAttributeTypes"
+    static let htmlAttributesFoundation: Self = "HTMLAttributeTypesFoundation"
     static let htmlElements: Self = "HTMLElementTypes"
     static let htmlTypesFoundation: Self = "HTMLTypesFoundation"
 }
 
 extension Target.Dependency {
     static var htmlAttributes: Self { .target(name: .htmlAttributes) }
+    static var htmlAttributesFoundation: Self { .target(name: .htmlAttributesFoundation) }
     static var htmlElements: Self { .target(name: .htmlElements) }
     static var htmlTypes: Self { .target(name: .htmlTypes) }
     static var htmlTypesFoundation: Self { .target(name: .htmlTypesFoundation) }
@@ -23,6 +25,7 @@ let package = Package(
         .library(name: .htmlTypes, targets: [.htmlTypes]),
         .library(name: .htmlTypesFoundation, targets: [.htmlTypesFoundation]),
         .library(name: .htmlAttributes, targets: [.htmlAttributes]),
+        .library(name: .htmlAttributesFoundation, targets: [.htmlAttributesFoundation]),
         .library(name: .htmlElements, targets: [.htmlElements])
     ],
     dependencies: [],
@@ -42,6 +45,18 @@ let package = Package(
             name: .htmlAttributes.tests,
             dependencies: [
                 .htmlAttributes
+            ]
+        ),
+        .target(
+            name: .htmlAttributesFoundation,
+            dependencies: [
+                .htmlAttributes
+            ]
+        ),
+        .testTarget(
+            name: .htmlAttributesFoundation.tests,
+            dependencies: [
+                .htmlAttributesFoundation
             ]
         ),
         .target(

--- a/Sources/HTMLAttributeTypes/Href.swift
+++ b/Sources/HTMLAttributeTypes/Href.swift
@@ -10,8 +10,6 @@
 //
 // ===----------------------------------------------------------------------===//
 
-import Foundation
-
 /// An attribute that specifies the URL that a hyperlink points to.
 ///
 /// The `href` attribute is most commonly used on `<a>` elements to create hyperlinks,
@@ -78,13 +76,6 @@ public struct Href: StringAttribute {
 }
 
 extension Href {
-    /// Create an Href from a Foundation.URL
-    /// - Parameter url: The URL to convert to an Href
-    /// - Returns: An Href with the URL's absolute string representation
-    public static func url(_ url: URL) -> Href {
-        return Href(value: url.absoluteString)
-    }
-
     /// Create an Href for a telephone number
     /// - Parameter phoneNumber: The phone number (can include country code, dashes, spaces, etc.)
     /// - Returns: An Href with a tel: scheme
@@ -99,32 +90,6 @@ extension Href {
         return Href(value: "mailto:\(email)")
     }
 
-    /// Create an Href for an email address with subject and body
-    /// - Parameters:
-    ///   - email: The email address
-    ///   - subject: Optional email subject
-    ///   - body: Optional email body
-    /// - Returns: An Href with a mailto: scheme and query parameters
-    public static func mailto(_ email: String, subject: String? = nil, body: String? = nil) -> Href {
-        var components = URLComponents()
-        components.scheme = "mailto"
-        components.path = email
-
-        var queryItems: [URLQueryItem] = []
-        if let subject = subject {
-            queryItems.append(URLQueryItem(name: "subject", value: subject))
-        }
-        if let body = body {
-            queryItems.append(URLQueryItem(name: "body", value: body))
-        }
-
-        if !queryItems.isEmpty {
-            components.queryItems = queryItems
-        }
-
-        return Href(value: components.string ?? "mailto:\(email)")
-    }
-
     /// Create an Href for SMS
     /// - Parameter phoneNumber: The phone number to send SMS to
     /// - Returns: An Href with an sms: scheme
@@ -132,32 +97,11 @@ extension Href {
         return Href(value: "sms:\(phoneNumber)")
     }
 
-    /// Create an Href for SMS with body text
-    /// - Parameters:
-    ///   - phoneNumber: The phone number to send SMS to
-    ///   - body: The message body
-    /// - Returns: An Href with an sms: scheme and body parameter
-    public static func sms(_ phoneNumber: String, body: String) -> Href {
-        var components = URLComponents()
-        components.scheme = "sms"
-        components.path = phoneNumber
-        components.queryItems = [URLQueryItem(name: "body", value: body)]
-
-        return Href(value: components.string ?? "sms:\(phoneNumber)")
-    }
-
     /// Create an Href for a file URL
     /// - Parameter path: The file path
     /// - Returns: An Href with a file: scheme
     public static func file(_ path: String) -> Href {
         return Href(value: "file://\(path)")
-    }
-
-    /// Create an Href for a file URL from a file URL
-    /// - Parameter fileURL: A file URL
-    /// - Returns: An Href with the file URL's absolute string
-    public static func file(_ fileURL: URL) -> Href {
-        return Href(value: fileURL.absoluteString)
     }
 
     /// Create an Href for a fragment (anchor) within the current page
@@ -172,16 +116,6 @@ extension Href {
     /// - Returns: An Href with a WhatsApp URL scheme
     public static func whatsapp(_ phoneNumber: String) -> Href {
         return Href(value: "https://wa.me/\(phoneNumber)")
-    }
-
-    /// Create an Href for WhatsApp with message
-    /// - Parameters:
-    ///   - phoneNumber: The phone number (with country code)
-    ///   - message: Pre-filled message text
-    /// - Returns: An Href with a WhatsApp URL scheme and message
-    public static func whatsapp(_ phoneNumber: String, message: String) -> Href {
-        let encodedMessage = message.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? message
-        return Href(value: "https://wa.me/\(phoneNumber)?text=\(encodedMessage)")
     }
 
     /// Create an Href for FaceTime

--- a/Sources/HTMLAttributeTypesFoundation/Href.swift
+++ b/Sources/HTMLAttributeTypesFoundation/Href.swift
@@ -1,0 +1,80 @@
+// ===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2025 Coen ten Thije Boonkkamp
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ===----------------------------------------------------------------------===//
+
+import Foundation
+import HTMLAttributeTypes
+
+extension Href {
+    /// Create an Href from a Foundation.URL
+    /// - Parameter url: The URL to convert to an Href
+    /// - Returns: An Href with the URL's absolute string representation
+    public static func url(_ url: URL) -> Href {
+        return Href(value: url.absoluteString)
+    }
+
+    /// Create an Href for an email address with subject and body
+    /// - Parameters:
+    ///   - email: The email address
+    ///   - subject: Optional email subject
+    ///   - body: Optional email body
+    /// - Returns: An Href with a mailto: scheme and query parameters
+    public static func mailto(_ email: String, subject: String? = nil, body: String? = nil) -> Href {
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = email
+
+        var queryItems: [URLQueryItem] = []
+        if let subject = subject {
+            queryItems.append(URLQueryItem(name: "subject", value: subject))
+        }
+        if let body = body {
+            queryItems.append(URLQueryItem(name: "body", value: body))
+        }
+
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        return Href(value: components.string ?? "mailto:\(email)")
+    }
+
+    /// Create an Href for SMS with body text
+    /// - Parameters:
+    ///   - phoneNumber: The phone number to send SMS to
+    ///   - body: The message body
+    /// - Returns: An Href with an sms: scheme and body parameter
+    public static func sms(_ phoneNumber: String, body: String) -> Href {
+        var components = URLComponents()
+        components.scheme = "sms"
+        components.path = phoneNumber
+        components.queryItems = [URLQueryItem(name: "body", value: body)]
+
+        return Href(value: components.string ?? "sms:\(phoneNumber)")
+    }
+
+    /// Create an Href for a file URL from a file URL
+    /// - Parameter fileURL: A file URL
+    /// - Returns: An Href with the file URL's absolute string
+    public static func file(_ fileURL: URL) -> Href {
+        return Href(value: fileURL.absoluteString)
+    }
+
+    /// Create an Href for WhatsApp with message
+    /// - Parameters:
+    ///   - phoneNumber: The phone number (with country code)
+    ///   - message: Pre-filled message text
+    /// - Returns: An Href with a WhatsApp URL scheme and message
+    public static func whatsapp(_ phoneNumber: String, message: String) -> Href {
+        let encodedMessage = message.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? message
+        return Href(value: "https://wa.me/\(phoneNumber)?text=\(encodedMessage)")
+    }
+}

--- a/Sources/HTMLTypesFoundation/Attributes/Accept.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Accept.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/AcceptCharset.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/AcceptCharset.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Action.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Action.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 
 extension Action {

--- a/Sources/HTMLTypesFoundation/Attributes/Allowfullscreen.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Allowfullscreen.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Alt.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Alt.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/As.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/As.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Async.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Async.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/AttributionSrc.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/AttributionSrc.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Autocomplete.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Autocomplete.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Autoplay.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Autoplay.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Behavior.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Behavior.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Blocking.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Blocking.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ButtonType.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ButtonType.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Capture.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Capture.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Checked.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Checked.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Cite.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Cite.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ColSpan.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ColSpan.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Color.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Color.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Compact.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Compact.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Controls.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Controls.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ControlsList.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ControlsList.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Crossorigin.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Crossorigin.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/DateTime.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/DateTime.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Default.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Default.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Defer.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Defer.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Direction.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Direction.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Dirname.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Dirname.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/DisablePictureInPicture.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/DisablePictureInPicture.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/DisableRemotePlayback.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/DisableRemotePlayback.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Disabled.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Disabled.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Download.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Download.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Elementtiming.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Elementtiming.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Enctype.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Enctype.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Face.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Face.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Fetchpriority.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Fetchpriority.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/FontSize.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/FontSize.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/For.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/For.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Form.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Form.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/FormAction.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/FormAction.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/FormEncType.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/FormEncType.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/FormMethod.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/FormMethod.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/FormNovalidate.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/FormNovalidate.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/FormTarget.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/FormTarget.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Autocapitalize.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Autocapitalize.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Autocorrect.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Autocorrect.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Autofocus.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Autofocus.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Class.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Class.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Contenteditable.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Contenteditable.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/DataAttribute.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/DataAttribute.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Dir.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Dir.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Draggable.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Draggable.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Enterkeyhint.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Enterkeyhint.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Exportparts.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Exportparts.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Hidden.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Hidden.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Id.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Id.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Inert.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Inert.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Inputmode.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Inputmode.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Is.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Is.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Itemid.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Itemid.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Itemprop.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Itemprop.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Itemref.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Itemref.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Itemscope.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Itemscope.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Itemtype.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Itemtype.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Lang.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Lang.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Nonce.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Nonce.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 
 extension Nonce {

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Part.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Part.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Popover.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Popover.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Slot.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Slot.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Spellcheck.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Spellcheck.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Style.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Style.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Tabindex.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Tabindex.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Title.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Title.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Translate.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Translate.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Virtualkeyboardpolicy.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Virtualkeyboardpolicy.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Global/Writingsuggestions.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Global/Writingsuggestions.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Headers.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Headers.swift
@@ -28,7 +28,12 @@
 /// Created by Coen ten Thije Boonkkamp on 08/04/2025.
 ///
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 
 public typealias Headers = HTMLAttributeTypes.Headers

--- a/Sources/HTMLTypesFoundation/Attributes/Height.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Height.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/High.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/High.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Hreflang.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Hreflang.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ImageSrcSet.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ImageSrcSet.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Imagesizes.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Imagesizes.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Integrity.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Integrity.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/IsMap.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/IsMap.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Kind.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Kind.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/LinkType.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/LinkType.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/List.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/List.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ListType.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ListType.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Loop.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Loop.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Low.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Low.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Maxlength.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Maxlength.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Media.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Media.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Method.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Method.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Minlength.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Minlength.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Multiple.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Multiple.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Muted.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Muted.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Name.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Name.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/NoResize.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/NoResize.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Nomodule.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Nomodule.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Novalidate.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Novalidate.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ObjectData.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ObjectData.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 
 extension ObjectData {

--- a/Sources/HTMLTypesFoundation/Attributes/ObjectForm.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ObjectForm.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ObjectType.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ObjectType.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Open.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Open.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Optimum.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Optimum.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Pattern.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Pattern.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Ping.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Ping.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Placeholder.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Placeholder.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Playsinline.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Playsinline.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/PopoverTarget.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/PopoverTarget.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/PopoverTargetAction.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/PopoverTargetAction.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Poster.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Poster.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Preload.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Preload.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Readonly.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Readonly.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ReferrerPolicy.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ReferrerPolicy.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Rel.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Rel.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Required.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Required.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Reversed.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Reversed.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/RowSpan.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/RowSpan.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Scope.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Scope.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ScriptType.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ScriptType.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Selected.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Selected.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ShadowRootClonable.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ShadowRootClonable.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ShadowRootDelegatesFocus.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ShadowRootDelegatesFocus.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/ShadowRootMode.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/ShadowRootMode.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Size.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Size.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Sizes.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Sizes.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Span.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Span.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Src.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Src.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 
 extension Src {

--- a/Sources/HTMLTypesFoundation/Attributes/Start.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Start.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Step.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Step.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Target.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Target.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/TextareaWrap.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/TextareaWrap.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Truespeed.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Truespeed.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Usemap.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Usemap.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Value.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Value.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Width.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Width.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Sources/HTMLTypesFoundation/Attributes/Xmlns.swift
+++ b/Sources/HTMLTypesFoundation/Attributes/Xmlns.swift
@@ -10,5 +10,10 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes

--- a/Tests/HTMLAttributeTypes Tests/Attribute Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Attribute Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/BooleanAttribute Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/BooleanAttribute Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Autocapitalize Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Autocapitalize Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Autocorrect Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Autocorrect Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Autofocus Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Autofocus Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Class Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Class Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Contenteditable Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Contenteditable Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/DataAttribute Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/DataAttribute Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Dir Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Dir Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Draggable Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Draggable Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Enterkeyhint Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Enterkeyhint Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Hidden Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Hidden Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Id Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Id Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Inert Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Inert Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Inputmode Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Inputmode Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Is Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Is Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Itemid Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Itemid Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Itemprop Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Itemprop Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Itemref Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Itemref Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Itemscope Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Itemscope Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Itemtype Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Itemtype Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Lang Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Lang Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Part Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Part Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Popover Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Popover Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Slot Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Slot Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Spellcheck Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Spellcheck Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Style Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Style Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Tabindex Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Tabindex Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Title Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Title Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Translate Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Translate Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Virtualkeyboardpolicy Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Virtualkeyboardpolicy Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/Global/Writingsuggestions Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/Global/Writingsuggestions Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLAttributeTypes Tests/StringAttribute Tests.swift
+++ b/Tests/HTMLAttributeTypes Tests/StringAttribute Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import Testing
 

--- a/Tests/HTMLElementTypes Tests/<a> Anchor Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<a> Anchor Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<abbr> Abbreviation Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<abbr> Abbreviation Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<address> Address Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<address> Address Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<area> Area Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<area> Area Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<article> Article Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<article> Article Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<aside> Aside Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<aside> Aside Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<audio> Audio Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<audio> Audio Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<b> Bring Attention To Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<b> Bring Attention To Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<base> Document Base URL Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<base> Document Base URL Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<body> Body Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<body> Body Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<br> Line Break Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<br> Line Break Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<button> Button Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<button> Button Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<form> Form Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<form> Form Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<h1-h6> HTML Section Heading Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<h1-h6> HTML Section Heading Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<label> Label Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<label> Label Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<link> External Resource Link Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<link> External Resource Link Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<meta> Meta Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<meta> Meta Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<script> Script Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<script> Script Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing

--- a/Tests/HTMLElementTypes Tests/<title> Title Tests.swift
+++ b/Tests/HTMLElementTypes Tests/<title> Title Tests.swift
@@ -10,7 +10,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#elseif canImport(Foundation)
 import Foundation
+#endif
+
 import HTMLAttributeTypes
 import HTMLElementTypes
 import Testing


### PR DESCRIPTION
- import `FoundationEssentials` instead of `Foundation` where applicable
- moved some foundation-dependent logic from `HTMLAttributeTypes` to `HTMLAttributeTypesFoundation`

This helps in reducing binary size and is a step closer to supporting embedded.